### PR TITLE
Fix peer dep clash with @capacitor/core 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "~3.8.3"
   },
   "peerDependencies": {
-    "@capacitor/core": "^2.4.0"
+    "@capacitor/core": ">=2.4.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
This should resolve npm falling over when installing with Capacitor core v3 or later already in place.